### PR TITLE
Assets (.JS and .CSS) should only load on post types when enabled

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 ## Change log
 
+### 1.1.3
+* Dev - The js and css assets front end assets for this plugin will only load in each post type if the sharing option is enabled for the post type.
+
 ### 1.1.2 - September 27
 * Dev - Adding the .gitattributes file to remove unnecessary files from the WordPress version.
 * Fix - Changing the wp_enqueue_script priority

--- a/classes/class-lsx-sharing-admin.php
+++ b/classes/class-lsx-sharing-admin.php
@@ -124,6 +124,7 @@ if ( ! class_exists( 'LSX_Sharing_Admin' ) ) {
 		public function display_settings( $tab = 'general' ) {
 			if ( 'sharing' === $tab ) {
 				$this->general_fields();
+				$this->post_type_fields_disable_all();
 				$this->post_type_fields();
 				$this->social_network_fields();
 			}
@@ -158,6 +159,30 @@ if ( ! class_exists( 'LSX_Sharing_Admin' ) ) {
 			*/
 
 			?>
+			<?php
+		}
+
+		/**
+		 * Disable all share buttons
+		 *
+		 * @return void
+		 */
+		public function post_type_fields_disable_all() {
+			?>
+			<tr class="form-field">
+				<th scope="row" colspan="2">
+					<h3><?php esc_html_e( 'Disable all share buttons on the site', 'lsx-sharing' ); ?></h3>
+				</th>
+			</tr>
+			<tr class="form-field">
+				<th scope="row">
+					<label for="sharing_disable_all"><?php esc_html_e( 'Disable All', 'lsx-sharing' ); ?></label>
+				</th>
+				<td>
+					<input type="checkbox" {{#if sharing_disable_all}} checked="checked" {{/if}} name="sharing_disable_all" />
+					<small><?php esc_html_e( 'Disable All share button.', 'lsx-sharing' ); ?></small>
+				</td>
+			</tr>
 			<?php
 		}
 

--- a/classes/class-lsx-sharing-frontend.php
+++ b/classes/class-lsx-sharing-frontend.php
@@ -51,22 +51,45 @@ if ( ! class_exists( 'LSX_Sharing_Frontend' ) ) {
 		 * Enques the assets.
 		 */
 		public function assets() {
+
+			//Set our variables
+			global $post;
+			$post_id    = false;
+			$share_post = $post;
+			if ( false !== $post_id ) {
+				$share_post = get_post( $post_id );
+				$post_type  = get_post_type( $post_id );
+			} else {
+				$post_type = get_post_type();
+			}
+
 			if ( defined( 'WP_DEBUG' ) && true === WP_DEBUG ) {
 				$min = '';
 			} else {
 				$min = '.min';
 			}
 
-			wp_enqueue_script( 'lsx-sharing', LSX_SHARING_URL . 'assets/js/lsx-sharing' . $min . '.js', array( 'jquery' ), LSX_SHARING_VER, true );
+			/* Remove assets completely if all sharing options are off */
+			if ( isset( $this->options['display'] ) && ! empty( $this->options['display']['sharing_disable_all'] ) ) {
+				return '';
+			}
 
-			$params = apply_filters( 'lsx_sharing_js_params', array(
-				'ajax_url' => admin_url( 'admin-ajax.php' ),
-			));
+			/* Only show the assets if the post type sharing option is on */
+			if ( isset( $this->options['display'] ) && empty( $this->options['display'][ 'sharing_disable_pt_' . $post_type ] ) ) {
 
-			wp_localize_script( 'lsx-sharing', 'lsx_sharing_params', $params );
+				wp_enqueue_script( 'lsx-sharing', LSX_SHARING_URL . 'assets/js/lsx-sharing' . $min . '.js', array( 'jquery' ), LSX_SHARING_VER, true );
 
-			wp_enqueue_style( 'lsx-sharing', LSX_SHARING_URL . 'assets/css/lsx-sharing.css', array(), LSX_SHARING_VER );
-			wp_style_add_data( 'lsx-sharing', 'rtl', 'replace' );
+				$params = apply_filters( 'lsx_sharing_js_params', array(
+					'ajax_url' => admin_url( 'admin-ajax.php' ),
+				));
+
+				wp_localize_script( 'lsx-sharing', 'lsx_sharing_params', $params );
+
+				wp_enqueue_style( 'lsx-sharing', LSX_SHARING_URL . 'assets/css/lsx-sharing.css', array(), LSX_SHARING_VER );
+				wp_style_add_data( 'lsx-sharing', 'rtl', 'replace' );
+
+			}
+
 		}
 
 		/**
@@ -89,11 +112,11 @@ if ( ! class_exists( 'LSX_Sharing_Frontend' ) ) {
 				$post_type = get_post_type();
 			}
 
-			if ( isset( $this->options['display'] ) && ! empty( $this->options['display'][ 'sharing_disable_pt_' . $post_type ] ) ) {
+			if ( isset( $this->options['display'] ) && ! empty( $this->options['display'][ 'sharing_disable_pt_' . $post_type ] ) && ! empty( $this->options['display']['sharing_disable_all'] ) ) {
 				return '';
 			}
 
-			if ( is_array( $buttons ) && count( $buttons ) > 0 ) {
+			if ( ( is_array( $buttons ) && count( $buttons ) > 0 ) && empty( $this->options['display'][ 'sharing_disable_pt_' . $post_type ] ) && empty( $this->options['display']['sharing_disable_all'] ) ) {
 				$sharing_content .= '<div class="lsx-sharing-content"><p>';
 
 				if ( isset( $this->options['display'] ) && ! empty( $this->options['display']['sharing_label_text'] ) ) {


### PR DESCRIPTION
### Description of the Change

This code adds a general option to turn off all share options on all posts types, this will prevent html and assets to load.
This code also adds conditional logic to check if the general disable option is off, and then check which post type has the social functionality enabled, then it will only load assets and html on the post types that has the social functionality on.

<img width="525" alt="Screen Shot 2020-03-13 at 11 59 47 AM" src="https://user-images.githubusercontent.com/3129483/76632562-29a20980-6522-11ea-93d5-d07d18ddda10.png">

### Benefits

The assets from this plugin will not be loaded across the entire website front-end, but only where they are needed, reducing loading times.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Applicable Issues

https://github.com/lightspeeddevelopment/lsx-sharing/issues/2

### Changelog Entry

* Dev - The js and css assets front end assets for this plugin will only load in each post type if the sharing option is enabled for the post type.
