### PR TITLE
2.0.0 - Plugin Review

### DIFF
--- a/developer.md
+++ b/developer.md
@@ -1,44 +1,7 @@
-# Contents
-
 # Setup
 
-## Step 1
-Skip this step if you have node installed globally already.
+## Install NPM
+Open your terminal and run `npm install` to install the correct modules locally.
 
-Open your terminal and run `npm install -g`
-
-
-## Important
-
-You may need to still install a package globally if it is missing from your folder.
-```
-npm install -g <package>
-```
-
-## Step 2
-```
-npm link gulp
-npm link gulp-autoprefixer
-npm link gulp-concat
-npm link gulp-gettext
-npm link gulp-jshint
-npm link gulp-plumber
-npm link gulp-rename
-npm link gulp-rtlcss
-npm link gulp-sass
-npm link gulp-sort
-npm link gulp-sourcemaps
-npm link gulp-uglify
-npm link gulp-util
-npm link gulp-wp-pot
-npm link map-stream
-```
-
-### Tips
-
-If you are having problems try set the permissions for the global node modules folder.
-
-```
-sudo chown -R root:YOUR_USERNAME /usr/local/lib/node_modules/
-sudo chmod -R 775 /usr/local/lib/node_modules/
-```
+## Build the block
+`npm run build-blocks` will compile the `build/block.js` file

--- a/includes/classes/class-sharing.php
+++ b/includes/classes/class-sharing.php
@@ -13,13 +13,6 @@ namespace LSX\Sharing;
  */
 class Sharing {
 
-    /**
-     * The options for the plugin.
-     *
-     * @var array
-     */
-    public $options = array();
-
 	/**
 	 * Holds the current variables for the url
 	 *


### PR DESCRIPTION
### Description
We have created 2 Blocks for this plugin, to allow the user to share the current page url to one of 4 social media platforms. The blocks are used within the `core/social-links` block, in order to piggy back on its options, colours, sizes etc.

#### Blocks Included
A "Sharing Link" block, which is similar to the `core/social-link` block, except the URL is specified.  So you don't have to enter any variables, you simply add them them to the page.
- Whatsapp Share
- Twitter Share
- Facebook Share
- Pinterest Share

And a "Share Label" block, allowing you to a label and icon inline with your sharing links.
- Share Label

### How to use

1. Add a "Social Icons" block to your page / template
2. Click the + button to add blocks to the "Social Icons" block
3. Type "Share" in the search input, to return the 5 Sharing Blocks available.
4. The "Share Label" has the option to display a share icon before the text, as well as colour and font size options in case you want the label smaller and a different colour to the icons.
5. Save the page and view the frontend.

NB - It handles all of the settings of the `core/social-links` block.

### How it Works

The "Sharing Links" block saves a URL with specific URL parameters stored in it.  [Variation URLs](https://github.com/lightspeeddevelopment/lsx-sharing/blob/4.0.0/review-request/src/sharing-link/variations.js#L6-L54)

On the frontend, we filter the block and replace the variable with the current page values.
[replace_variables() - class-sharing.php#L264](https://github.com/lightspeeddevelopment/lsx-sharing/blob/4.0.0/review-request/includes/classes/class-sharing.php#L264)

NB - The Pinterest Share is the only one which send through an image in the URL parameters. It defaults to the custom logo if that is set.

#### OpenGraph
If you have a plugin (e.g [Yoast](https://wordpress.org/plugins/wordpress-seo/)) which adds the [OpenGraph](https://ogp.me/) tags to the site, then the description etc pulls through.  We install that on all of our sites, so the LSX Sharing is meant to be used in conjunction with it.  But it's not needed.

### Issues
- [ ] Editor - "Sharing Links" are not outputting the [button](https://github.com/lightspeeddevelopment/lsx-sharing/blob/4.0.0/review-request/src/sharing-link/edit.js#L51) the same as "Social Icon" does.  Resulting in a narrow button. (fix with CSS, disable button click)
- [ ] Editor - The input on the "Share Label" prevents the colour and font size options from affecting it. 

### TODO
- [ ] Remove the `Mail (popup)` variation (this will feature in version 2.1) 

### Screenshots
![Screenshot 2023-03-31 at 21 48 58](https://user-images.githubusercontent.com/1805603/229215866-4ff09360-3249-480b-84ec-00effd348fa4.png)  
![Screenshot 2023-03-31 at 21 52 18](https://user-images.githubusercontent.com/1805603/229216667-7de1a12e-91a3-4e2d-be05-655def3cf4ba.png)



